### PR TITLE
Update build.yml to use actions/upload-artifact V4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           make clean
           make FEAT_ALL="Y" TOGL_LOGGING="Y" -j4
       - name: store - FEAT_ALL TOGL_LOGGING
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sys-tweak_log.nsp
           path: out/sys-tweak.nsp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           make clean
           make FEAT_ALL="Y" -j4
       - name: store - FEAT_ALL
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sys-tweak.nsp
           path: out/sys-tweak.nsp


### PR DESCRIPTION
currently V2 is being used, which was [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) meaning github action builds fail.